### PR TITLE
Moved minimum version to iOS 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "LineChartView",
     platforms: [
-        .iOS(.v15)
+        .iOS(.v14)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Tests/LineChartViewTests/LineChartViewTests.swift
+++ b/Tests/LineChartViewTests/LineChartViewTests.swift
@@ -1,11 +1,4 @@
 import XCTest
 @testable import LineChartView
 
-final class LineChartViewTests: XCTestCase {
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        XCTAssertEqual(LineChartView().text, "Hello, World!")
-    }
-}
+final class LineChartViewTests: XCTestCase { }


### PR DESCRIPTION
The project didn't need a minimum deployment target of iOS 15, so I moved it down to 14 so I could use it in a project for work.

The only consequence is the removal of an unnecessary test, which was causing the package build to fail.