### PR TITLE
Wip 5 - Option to set precision of data

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ To customize your chart, you can set parameters of `LineChartParameters`. Here a
 - `labelColor`: Color of values text
 - `secondaryLabelColor`: Color of labels text
 - `labelsAlignment`: `.left`, `.center`, `.right` to align both labels above chart
-- `dataFractionLength`: Number of digits after the decimal point. Default to `2`. Warning: Only available on iOS 15+.
+- `dataPrecisionLength`: Number of digits after the decimal point (round value). Default to `2`. Warning: Only available on iOS 15+.
 - `indicatorPointColor`: Color of indicator point displayed when user drags finger on chart
 - `indicatorPointSize`: Size of indicator point
 - `lineColor`: First color of line
@@ -154,7 +154,7 @@ let chartParameters = LineChartParameters(
     labelColor: .primary,
     secondaryLabelColor: .secondary,
     labelsAlignment: .left,
-    dataFractionLength: 0,
+    dataPrecisionLength: 0,
     indicatorPointColor: .blue,
     indicatorPointSize: 20,
     lineColor: .blue,

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To set your chart as a time serie, simply set `dataTimestamps` parameter with an
 - Add labels to each value (as `String`)
 - Change label (value) and secondary label colors
 - Change labels alignment (left, center, right)
+- Change number of digits after decimal point
 - Change indicator point color and size
 - Change line color (simple color or linear gradient with two colors)
 - Display dots for each point/value on line
@@ -133,6 +134,7 @@ To customize your chart, you can set parameters of `LineChartParameters`. Here a
 - `labelColor`: Color of values text
 - `secondaryLabelColor`: Color of labels text
 - `labelsAlignment`: `.left`, `.center`, `.right` to align both labels above chart
+- `dataFractionLength`: Number of digits after the decimal point. Default to `2`. Warning: Only available on iOS 15+.
 - `indicatorPointColor`: Color of indicator point displayed when user drags finger on chart
 - `indicatorPointSize`: Size of indicator point
 - `lineColor`: First color of line
@@ -152,6 +154,7 @@ let chartParameters = LineChartParameters(
     labelColor: .primary,
     secondaryLabelColor: .secondary,
     labelsAlignment: .left,
+    dataFractionLength: 0,
     indicatorPointColor: .blue,
     indicatorPointSize: 20,
     lineColor: .blue,

--- a/Sources/LineChartView/Components/ChartLabels.swift
+++ b/Sources/LineChartView/Components/ChartLabels.swift
@@ -40,10 +40,17 @@ public struct ChartLabels: View {
             
             VStack(alignment: lineChartParameters.labelsAlignment == .left ? .leading : lineChartParameters.labelsAlignment == .right ? .trailing : .center) {
                 if  lineChartParameters.data.count > indexPosition {
-                    Text(String(format: "%.2f", lineChartParameters.data[indexPosition]))
-                        .foregroundColor(lineChartParameters.labelColor)
-                        .font(.title)
-                        .fontWeight(.bold)
+                    if #available(iOS 15.0, *) {
+                        Text(lineChartParameters.data[indexPosition].formatted(.number.precision(.fractionLength(lineChartParameters.dataFractionLength))))
+                            .foregroundColor(lineChartParameters.labelColor)
+                            .font(.title)
+                            .fontWeight(.bold)
+                    } else {
+                        Text(String(format: "%.2f", lineChartParameters.data[indexPosition]))
+                            .foregroundColor(lineChartParameters.labelColor)
+                            .font(.title)
+                            .fontWeight(.bold)
+                    }
                 }
             
                 if labels.count > indexPosition {

--- a/Sources/LineChartView/Components/ChartLabels.swift
+++ b/Sources/LineChartView/Components/ChartLabels.swift
@@ -41,7 +41,7 @@ public struct ChartLabels: View {
             VStack(alignment: lineChartParameters.labelsAlignment == .left ? .leading : lineChartParameters.labelsAlignment == .right ? .trailing : .center) {
                 if  lineChartParameters.data.count > indexPosition {
                     if #available(iOS 15.0, *) {
-                        Text(lineChartParameters.data[indexPosition].formatted(.number.precision(.fractionLength(lineChartParameters.dataFractionLength))))
+                        Text(lineChartParameters.data[indexPosition].formatted(.number.precision(.fractionLength(lineChartParameters.dataPrecisionLength))))
                             .foregroundColor(lineChartParameters.labelColor)
                             .font(.title)
                             .fontWeight(.bold)

--- a/Sources/LineChartView/LineChartParameters.swift
+++ b/Sources/LineChartView/LineChartParameters.swift
@@ -21,7 +21,7 @@ public class LineChartParameters {
     public var secondaryLabelColor: Color
     public var labelsAlignment: ChartLabels.Alignment
     
-    public var dataFractionLength: Int
+    public var dataPrecisionLength: Int
     
     public var indicatorPointColor: Color
     public var indicatorPointSize: CGFloat
@@ -45,7 +45,7 @@ public class LineChartParameters {
         secondaryLabelColor: Color = .secondary,
         labelsAlignment: ChartLabels.Alignment = .left,
         
-        dataFractionLength: Int = 2, // Only available on iOS 15+
+        dataPrecisionLength: Int = 2, // Only available on iOS 15+
         
         indicatorPointColor: Color = .blue,
         indicatorPointSize: CGFloat = 20,
@@ -70,7 +70,7 @@ public class LineChartParameters {
         self.labelColor = labelColor
         self.secondaryLabelColor = secondaryLabelColor
         self.labelsAlignment = labelsAlignment
-        self.dataFractionLength = dataFractionLength
+        self.dataPrecisionLength = dataPrecisionLength
         self.indicatorPointColor = indicatorPointColor
         self.indicatorPointSize = indicatorPointSize
         self.lineColor = lineColor

--- a/Sources/LineChartView/LineChartParameters.swift
+++ b/Sources/LineChartView/LineChartParameters.swift
@@ -21,6 +21,8 @@ public class LineChartParameters {
     public var secondaryLabelColor: Color
     public var labelsAlignment: ChartLabels.Alignment
     
+    public var dataFractionLength: Int
+    
     public var indicatorPointColor: Color
     public var indicatorPointSize: CGFloat
     
@@ -42,6 +44,8 @@ public class LineChartParameters {
         labelColor: Color = .primary,
         secondaryLabelColor: Color = .secondary,
         labelsAlignment: ChartLabels.Alignment = .left,
+        
+        dataFractionLength: Int = 2, // Only available on iOS 15+
         
         indicatorPointColor: Color = .blue,
         indicatorPointSize: CGFloat = 20,
@@ -66,6 +70,7 @@ public class LineChartParameters {
         self.labelColor = labelColor
         self.secondaryLabelColor = secondaryLabelColor
         self.labelsAlignment = labelsAlignment
+        self.dataFractionLength = dataFractionLength
         self.indicatorPointColor = indicatorPointColor
         self.indicatorPointSize = indicatorPointSize
         self.lineColor = lineColor


### PR DESCRIPTION
Set number of digits after decimal point. Set `dataPrecisionLength` of `LineChartParameters` to change default (`2`)  value.